### PR TITLE
Update Service Dependencies Table to use team identity

### DIFF
--- a/js/visualizations.js
+++ b/js/visualizations.js
@@ -1279,7 +1279,7 @@ function generateServiceDependenciesTable() {
         // Owning Team
         const team = currentSystemData.teams.find(t => t.teamId === service.owningTeamId);
         const teamCell = document.createElement('td');
-        teamCell.textContent = team ? team.teamName : 'Unassigned';
+        teamCell.textContent = team ? (team.teamIdentity || team.teamName) : 'Unassigned';
         row.appendChild(teamCell);
 
         // Upstream Dependencies (Services Depended On)


### PR DESCRIPTION
When the Service Dependency Visualization is active on the carousel, the 'Owning Team' column in the accompanying Service Dependencies Table will now display the team's identity (e.g., 'Avengers') instead of the team's full name (e.g., 'User Experience Team').

This change modifies the `generateServiceDependenciesTable` function in `js/visualizations.js` to use `team.teamIdentity`, with a fallback to `team.teamName` if the identity is not present.