### PR TITLE
Fix: Ensure consistent circular legends in visualization carousel

### DIFF
--- a/js/visualizations.js
+++ b/js/visualizations.js
@@ -468,6 +468,7 @@ function generateTeamVisualization(systemData) {
         .style('width', '12px')
         .style('height', '12px')
         .style('background-color', d => d.color)
+        .style('border-radius', '50%') // This makes it a circle
         .style('margin-right', '5px');
 
     legend.append('span')
@@ -737,6 +738,7 @@ function generateServiceVisualization(services, selectedServiceName) {
         .style('width', '12px')
         .style('height', '12px')
         .style('background-color', d => d.color)
+        .style('border-radius', '50%') // This makes it a circle
         .style('margin-right', '5px');
 
     legend.append('span')


### PR DESCRIPTION
Applied consistent styling for legend items across visualizations within the carousel.

- Modified `generateTeamVisualization` and `generateServiceVisualization` in `js/visualizations.js` to use `border-radius: '50%'` for their HTML-based legend item markers, ensuring they appear as circles.
- Reviewed `generateDependencyForceVisualization` and confirmed its SVG-based legend already correctly renders categorical items as circles.
- Verified that the carousel navigation logic in `js/main.js` correctly shows/hides legends in sync with their respective visualization panels.