### PR TITLE
feat: Add toggle to show/hide platform components in visualizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,8 @@
                     <span id="visualizationTitle" style="margin: 0 15px; font-weight: bold; font-size: 1.1em;">System Visualization</span> <button onclick="navigateVisualizations(1)">Next &gt;</button>
                 </div>
 
-                <div id="visualization" class="carousel-item" style="display: block;"> <svg id="systemSvg" style="width: 100%; height: 600px; border: 1px solid #ccc;"></svg>
+                <div id="visualization" class="carousel-item" style="display: block;"> <button id="togglePlatformComponentsSystem" class="button" style="margin-bottom: 10px;">Hide Platforms</button>
+<svg id="systemSvg" style="width: 100%; height: 600px; border: 1px solid #ccc;"></svg>
                     <div id="legend" class="legend"></div>
                 </div>
 
@@ -85,14 +86,16 @@
                 <div id="serviceRelationshipsVisualization" class="carousel-item" style="display: none;">
                     <select id="serviceSelection" onchange="updateServiceVisualization()" style="margin-bottom: 5px; display: block; margin-left: auto; margin-right: auto;">
                         </select>
-                    <svg id="serviceSvg" style="width: 100%; height: 600px; border: 1px solid #ccc;"></svg>
+                    <button id="togglePlatformComponentsService" class="button" style="margin-bottom: 10px;">Hide Platforms</button>
+<svg id="serviceSvg" style="width: 100%; height: 600px; border: 1px solid #ccc;"></svg>
                     <div id="serviceLegend" class="legend"></div>
                 </div>
 
                 <div id="dependencyVisualization" class="carousel-item" style="display: none;">
                     <select id="dependencyServiceSelection" onchange="updateDependencyVisualization()" style="margin-bottom: 5px; display: block; margin-left: auto; margin-right: auto;">
                         </select>
-                    <svg id="dependencySvg" style="width: 100%; height: 600px; border: 1px solid #ccc;"></svg>
+                    <button id="togglePlatformComponentsDependency" class="button" style="margin-bottom: 10px;">Hide Platforms</button>
+<svg id="dependencySvg" style="width: 100%; height: 600px; border: 1px solid #ccc;"></svg>
                     <div id="dependencyLegend" class="legend"></div>
                 </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -689,6 +689,14 @@ function loadSavedSystem(systemName) {
         const carouselDiv = document.getElementById('visualizationCarousel');
         if (carouselDiv) carouselDiv.innerHTML = '<p style="color:red">Error loading some visualization components. Check console.</p>';
     }
+
+    // Setup toggle buttons for platform components visibility
+    if (typeof window.setupPlatformToggleButtons === 'function') {
+        window.setupPlatformToggleButtons();
+        console.log("[V7 LOAD] Called setupPlatformToggleButtons.");
+    } else {
+        console.error("[V7 LOAD] setupPlatformToggleButtons function not found. Platform toggles will not work.");
+    }
 }
 // window.loadSavedSystem = loadSavedSystem; // Keep global
 


### PR DESCRIPTION
This commit introduces a feature allowing you to toggle the visibility of platform components in service visualizations.

Key changes:
- Added toggle buttons to the System, Service Relationships, and Dependency visualizations.
- Implemented logic in `js/visualizations.js` to show/hide platform nodes, associated links, and relevant legend entries based on a global toggle state.
- Ensured that the toggle buttons' text labels are synchronized across all visualizations, accurately reflecting the current visibility state.
- Integrated the button setup into the existing UI initialization flow in `js/main.js`.

The feature defaults to showing platform components. You can click the toggle buttons (initially "Hide Platforms") to hide platform-related elements, and click again ("Show Platforms") to reveal them. This state is shared across all three affected visualizations.