### PR TITLE
Fix: Service relationships dropdown stuck on 'All Services View'

### DIFF
--- a/js/visualizations.js
+++ b/js/visualizations.js
@@ -520,8 +520,7 @@ function getServiceDependencies(service, collectedServices = {}, visitedServices
 function updateServiceVisualization() {
     const selectedService = document.getElementById('serviceSelection').value;
 
-    // Ensure the service selection is populated with the latest data
-    populateServiceSelection();
+    // populateServiceSelection(); // <--- REMOVE THIS LINE
     
     if (selectedService === 'all') {
         generateServiceVisualization(currentSystemData.services, null); // No service is selected


### PR DESCRIPTION
I removed a redundant call to `populateServiceSelection` within the `updateServiceVisualization` function. This prevents the dropdown from resetting to 'All Services View' each time you select a service, ensuring the chosen service remains displayed and the visualization updates accordingly.